### PR TITLE
許可するホスト名にdaysync.jpを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,10 +88,11 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    "daysync.jp",     # メインドメイン
+    "www.daysync.jp", # wwwサブドメイン
+    "day-sync-app.fly.dev"  # fly.ioのデフォルトドメイン
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
- メインドメイン（daysync.jp）の追加
- wwwサブドメイン（www.daysync.jp）の追加
- デフォルトのfly.ioドメインの追加