### PR TITLE
HTTPSの強制設定を無効化

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -14,7 +14,7 @@ console_command = '/rails/bin/rails console'
 
 [http_service]
   internal_port = 3000
-  force_https = true
+  force_https = false
   auto_stop_machines = 'stop'
   auto_start_machines = true
   min_machines_running = 0


### PR DESCRIPTION
- HTTPSの強制設定(force_https)をfalseに変更