### PR TITLE
検索パネルのJavaScriptコードを整理

### DIFF
--- a/app/javascript/search_panel.js
+++ b/app/javascript/search_panel.js
@@ -2,91 +2,89 @@ document.addEventListener("turbo:load", function () {
   initializeSearchPanels();
 });
 
-document.addEventListener("turbo:render", function () {
-  initializeSearchPanels();
-});
-
 function initializeSearchPanels() {
   const searchPanelContainers = document.querySelectorAll(
     ".search-panel-container"
   );
 
   searchPanelContainers.forEach((container) => {
-    const toggleButton = container.querySelector(".search-panel-toggle");
-    const searchPanel = container.querySelector(".search-panel");
-    const toggleIcon = container.querySelector(".toggle-icon");
-    const clearButton = container.querySelector(".search-clear");
-    const searchForm = container.querySelector("form");
-
-    if (toggleButton && !toggleButton.hasAttribute("data-initialized")) {
-      toggleButton.setAttribute("data-initialized", "true");
-
-      searchPanel.style.display = "none";
-      toggleIcon.textContent = "▶";
-      toggleButton.classList.remove("active");
-
-      toggleButton.addEventListener("click", function () {
-        toggleSearchPanel(searchPanel, toggleIcon, toggleButton);
-      });
-    }
-
-    if (clearButton && !clearButton.hasAttribute("data-initialized")) {
-      clearButton.setAttribute("data-initialized", "true");
-
-      clearButton.addEventListener("click", async function (e) {
-        e.preventDefault();
-
-        const inputs = searchForm.querySelectorAll(
-          "input[type='text'], input[type='date'], select"
-        );
-
-        inputs.forEach((input) => {
-          if (input.tagName.toLowerCase() === "select") {
-            input.selectedIndex = 0;
-          } else {
-            input.value = "";
-          }
-        });
-
-        showSearchPanel(searchPanel, toggleIcon, toggleButton);
-
-        try {
-          const turboFrameId =
-            searchForm.dataset.turboFrame || clearButton.dataset.turboFrame;
-
-          if (!turboFrameId) {
-            console.error("No turbo frame ID found");
-            return;
-          }
-
-          const baseUrl = window.location.pathname;
-          const turboFrame = document.querySelector(`#${turboFrameId}`);
-
-          if (turboFrame) {
-            await Turbo.visit(baseUrl, {
-              frame: turboFrameId,
-              action: "replace",
-            });
-          }
-        } catch (error) {
-          console.error("Error during clear operation:", error);
-        }
-      });
-    }
+    setupTogglePanel(container);
+    setupClearButton(container);
   });
 }
 
-function showSearchPanel(panel, icon, button) {
-  if (panel && icon && button) {
-    panel.style.display = "block";
-    icon.textContent = "▼";
-    button.classList.add("active");
+function setupTogglePanel(container) {
+  const toggleButton = container.querySelector(".search-panel-toggle");
+  const searchPanel = container.querySelector(".search-panel");
+  const toggleIcon = container.querySelector(".toggle-icon");
+
+  if (toggleButton && !toggleButton.hasAttribute("data-initialized")) {
+    toggleButton.setAttribute("data-initialized", "true");
+    searchPanel.style.display = "none";
+    toggleIcon.textContent = "▶";
+    toggleButton.classList.remove("active");
+
+    toggleButton.addEventListener("click", function () {
+      toggleSearchPanel(searchPanel, toggleIcon, toggleButton);
+    });
+  }
+}
+
+function setupClearButton(container) {
+  const clearButton = container.querySelector(".search-clear");
+  const searchForm = container.querySelector("form");
+
+  if (clearButton && !clearButton.hasAttribute("data-initialized")) {
+    clearButton.setAttribute("data-initialized", "true");
+
+    clearButton.addEventListener("click", async function (e) {
+      e.preventDefault();
+      await clearSearchForm(searchForm, clearButton);
+    });
+  }
+}
+
+async function clearSearchForm(searchForm, clearButton) {
+  const inputs = searchForm.querySelectorAll(
+    "input[type='text'], input[type='date'], select"
+  );
+
+  inputs.forEach((input) => {
+    if (input.tagName.toLowerCase() === "select") {
+      input.selectedIndex = 0;
+    } else {
+      input.value = "";
+    }
+  });
+
+  try {
+    const turboFrameId =
+      searchForm.dataset.turboFrame || clearButton.dataset.turboFrame;
+
+    if (!turboFrameId) {
+      console.error("No turbo frame ID found");
+      return;
+    }
+
+    const baseUrl = window.location.pathname;
+    const turboFrame = document.querySelector(`#${turboFrameId}`);
+
+    if (turboFrame) {
+      await Turbo.visit(baseUrl, {
+        frame: turboFrameId,
+        action: "replace",
+      });
+    }
+  } catch (error) {
+    console.error("Error during clear operation:", error);
   }
 }
 
 function toggleSearchPanel(panel, icon, button) {
   if (panel.style.display === "none") {
-    showSearchPanel(panel, icon, button);
+    panel.style.display = "block";
+    icon.textContent = "▼";
+    button.classList.add("active");
   } else {
     panel.style.display = "none";
     icon.textContent = "▶";


### PR DESCRIPTION
- turbo:renderイベントリスナーを削除（turbo:loadのみで十分なため）
- 大きかったinitializeSearchPanels関数を以下の2つに分割：
  - setupTogglePanel: パネルの開閉機能を担当
  - setupClearButton: クリアボタンの機能を担当
- showSearchPanel関数を削除し、toggleSearchPanel内に統合
- clearボタンのエラーハンドリングを追加（console.error）